### PR TITLE
feat: add eslint 6 compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "danger": "^7.0.14",
     "esdoc": "^1.1.0",
-    "eslint": "^5.15.0",
+    "eslint": "^6.0.0",
     "husky": "^1.3.1",
     "jest": "^24.3.0",
     "lint-staged": "^8.1.5",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -152,4 +152,15 @@ describe("eslint()", () => {
     expect(global.fail).toHaveBeenCalledTimes(2)
     expect(global.fail).toHaveBeenLastCalledWith("a.json line 2 – 'console' is not defined. (no-undef)", "a.json", 2)
   })
+
+  it("should convert a eslint config passed in as a string to an object", async () => {
+    global.danger = {
+      github: { pr: { title: "Test" } },
+      git: { created_files: [], modified_files: [] },
+    }
+
+    await eslint(JSON.stringify(defaultConfig))
+
+    expect(global.fail).not.toHaveBeenCalled()
+  })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,8 +8,9 @@ const mockFileContents = (contents: string) => {
 }
 
 const defaultConfig = {
-  envs: ["browser"],
-  useEslintrc: false,
+  env: {
+    browser: true,
+  },
   extends: "eslint:recommended",
 }
 
@@ -69,7 +70,12 @@ describe("eslint()", () => {
       git: { created_files: ["foo.js"], modified_files: [] },
     }
 
-    await eslint(defaultConfig)
+    await eslint({
+      rules: {
+        "no-console": 2,
+        "no-undef": 2,
+      },
+    })
 
     expect(global.fail).toHaveBeenCalledTimes(2)
     expect(global.fail).toHaveBeenLastCalledWith("foo.js line 2 – 'console' is not defined. (no-undef)", "foo.js", 2)
@@ -133,7 +139,15 @@ describe("eslint()", () => {
       git: { created_files: ["a.json"], modified_files: [] },
     }
 
-    await eslint(defaultConfig, [".json"])
+    await eslint(
+      {
+        rules: {
+          "no-console": 2,
+          "no-undef": 2,
+        },
+      },
+      [".json"]
+    )
 
     expect(global.fail).toHaveBeenCalledTimes(2)
     expect(global.fail).toHaveBeenLastCalledWith("a.json line 2 – 'console' is not defined. (no-undef)", "a.json", 2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ interface Options {
  */
 export default async function eslint(config: any, extensions: string[] = [".js"]) {
   const allFiles = danger.git.created_files.concat(danger.git.modified_files)
+  if (typeof config === "string") {
+    config = JSON.parse(config)
+  }
   const options: Options = { baseConfig: config }
   if (extensions) {
     options.extensions = extensions

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ interface Options {
 /**
  * Eslint your code with Danger
  */
-export default async function eslint(config: any, extensions?: string[]) {
+export default async function eslint(config: any, extensions: string[] = [".js"]) {
   const allFiles = danger.git.created_files.concat(danger.git.modified_files)
   const options: Options = { baseConfig: config }
   if (extensions) {
@@ -25,7 +25,7 @@ export default async function eslint(config: any, extensions?: string[]) {
   const cli = new CLIEngine(options)
   // let eslint filter down to non-ignored, matching the extensions expected
   const filesToLint = allFiles.filter(f => {
-    return !cli.isPathIgnored(f) && cli.options.extensions.some(ext => f.endsWith(ext))
+    return !cli.isPathIgnored(f) && options.extensions.some(ext => f.endsWith(ext))
   })
   return Promise.all(filesToLint.map(f => lintFile(cli, config, f)))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,7 +589,7 @@ aggregate-error@^2.0.0:
     clean-stack "^2.0.0"
     indent-string "^3.0.0"
 
-ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -2237,10 +2237,10 @@ esdoc@^1.1.0:
     minimist "1.2.0"
     taffydb "2.7.3"
 
-eslint-scope@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.2.tgz#5f10cd6cabb1965bf479fa65745673439e21cb0e"
-  integrity sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -2255,32 +2255,33 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.15.0:
-  version "5.15.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.15.1.tgz#8266b089fd5391e0009a047050795b1d73664524"
-  integrity sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==
+eslint@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.0.tgz#9223f19223de73b4ed730e11bff44a376b65844d"
+  integrity sha512-SrrIfcd4tOgsspOKTSwamuTOAMZOUigHQhVMrzNjz4/B9Za6SHQDIocMIyIDfwDgx6MhS15nS6HC8kumCV2qBQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^4.0.2"
+    eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    espree "^6.0.0"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^3.1.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.2.2"
-    js-yaml "^3.12.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.11"
@@ -2288,7 +2289,6 @@ eslint@^5.15.0:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
@@ -2297,10 +2297,10 @@ eslint@^5.15.0:
     table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
+  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
   dependencies:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
@@ -4127,6 +4127,14 @@ js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
   integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
eslint 6 has removed the `cli.options` prop off the cli object and it doesn't seem to be available anywhere, from some test it seems that this always reflects the `options` passed in so we can default to `[".js"]` there and then use that in the check.

Additionally, eslint now longer converts a string to an object in the CLIEngine constructor, so if the config we're passed is a string convert it to an object.

eslint 6 also now seems have more validation around the object passed in, it seems the defaultConfig in the tests wasn't fully valid previously.