### PR TITLE
Support bitbucket cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^27.0.2",
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "^3.2.0",
-    "danger": "^10.2.1",
+    "danger": "https://github.com/FabienLydoire/danger-js/releases/download/11.2.3-patch/danger-11.2.3.tgz",
     "esdoc": "^1.1.0",
     "eslint": "^8.0.1",
     "husky": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^27.0.2",
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "^3.2.0",
-    "danger": "https://github.com/FabienLydoire/danger-js/releases/download/11.2.3-patch/danger-11.2.3.tgz",
+    "danger": "^11.2.6",
     "esdoc": "^1.1.0",
     "eslint": "^8.0.1",
     "husky": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export default async function eslint(config: any, extensions: string[] = [".js"]
 async function fileContents(path) {
   let contents: string
   if (danger.bitbucket_cloud != null) {
-    contents = await danger.bitbucket_cloud.api.getFileContents(path, danger.bitbucket_cloud.metadata.repoSlug, danger.bitbucket_cloud.pr.destination.commit.hash);
+    contents = await danger.bitbucket_cloud.api.getFileContents(path, danger.bitbucket_cloud.metadata.repoSlug, danger.bitbucket_cloud.pr.source.commit.hash);
   } else if (danger.bitbucket_server != null) {
     contents = await danger.bitbucket_server.api.getFileContents(path, danger.bitbucket_server.metadata.repoSlug, danger.bitbucket_server.pr.fromRef.id)
   } else if (danger.gitlab != null) {


### PR DESCRIPTION
Following the Danger update (See https://github.com/danger/danger-js/pull/1350), this PR adds support for:

- Bitbucket cloud
- Bitbucket server
- Gitlab
in addition to existing Github integration.